### PR TITLE
fix(nodeclass): update finalizer operation target in status controller

### DIFF
--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -66,7 +66,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ECSNodeC
 
 	if !controllerutil.ContainsFinalizer(nodeClass, v1alpha1.TerminationFinalizer) {
 		stored := nodeClass.DeepCopy()
-		controllerutil.AddFinalizer(stored, v1alpha1.TerminationFinalizer)
+		controllerutil.AddFinalizer(nodeClass, v1alpha1.TerminationFinalizer)
 
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Update the AddFinalizer operation to modify the nodeClass object directly instead of the stored copy. This change maintains the correct patch operation flow while making the code's intention clearer.

The stored copy should remain unmodified as it serves as the base state for calculating the patch difference, while nodeClass should receive the actual modifications.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE